### PR TITLE
Upgrade to alpine:3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.12
 
 RUN apk add imagemagick --update
 


### PR DESCRIPTION
Use a more recent alpine distribution `3.12`.

I tested this locally and was able to produce a JPG from a PDF successfully with the same command as before used in the https://github.com/elifesciences/personalised-covers project.